### PR TITLE
sanction modify fix

### DIFF
--- a/src/Sanction/EditSanctionModal/EditSanctionModal.tsx
+++ b/src/Sanction/EditSanctionModal/EditSanctionModal.tsx
@@ -22,7 +22,7 @@ const EditSanctionModal = (props: Props) => {
     const [newEndDate, setNewEndDate] = useState<Date>(new Date());
 
     useEffect(()=>{
-        if(props.sanction.endDate !== "") setNewEndDate(new Date(new Date(props.sanction.endDate).getTime()+86400000)); //offset of TimeZone turns Date to Date-1
+        if(props.sanction.endDate !== "") setNewEndDate(new Date(new Date(new Date(props.sanction.endDate).getTime()+86400000).setHours(23,59,59,0))); //offset of TimeZone turns Date to Date-1
     }, [props.sanction])
 
     const handleEdit = () => {


### PR DESCRIPTION
## Description

Debido a diferencias horarias por la timezone y el manejo de horas+minutos de React, en ciertas horas del día, no permitía modificar la fecha de una sanción a la fecha actual (para poder asi "cancelarla").
Con este fix ahora es posible en todo momento del día.

## ClubHouse Link

> https://app.clubhouse.io/bibliotecame/story/380/el-editar-sanci%C3%B3n-no-permite-ingresar-la-fecha-de-hoy


## Checklist
- [x] I've manually tested the feature and it works as expected
- [x] I've successfully integrated the feature with the API
- [x] This pull request has 'sprint_x' as the base branch
- [x] This pull request has a descriptive title and description
- [x] I have merged the current sprint into my branch before pushing
- [x] I've added the QA Leader as a reviewer
